### PR TITLE
Copy user guide files into /static/user-guide for web access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,36 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 </configuration>
             </plugin>
+
+            <!-- Copy the user guide files into the top-level "static" directory (link
+            to htm file in page_header.jsp) -->
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>copy-user-guide</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/${project.name}/static/user-guide</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>doc/user-guide</directory>
+                                    <includes>
+                                        <include>ug.*</include>
+                                        <include>images/*</include>
+                                        <include>icons/*</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -195,6 +221,7 @@
                     <cacheFile>checkstyle.cache</cacheFile>
                 </configuration>
             </plugin>
+
         </plugins>
     </build>
     <reporting>
@@ -206,7 +233,7 @@
             </plugin>
         </plugins>
     </reporting>
-	  
+
     <repositories>
         <repository>
             <id>osgeo</id>
@@ -217,7 +244,7 @@
             <id>geotoolkit</id>
             <name>Geo Toolkit Repository</name>
             <url>http://maven.geotoolkit.org/</url>
-        </repository>        
+        </repository>
         <!-- This is only for the temporary usage of JClouds snapshots-->
         <repository>
             <id>apache-snapshots</id>

--- a/src/main/webapp/WEB-INF/jsp/page_header.jsp
+++ b/src/main/webapp/WEB-INF/jsp/page_header.jsp
@@ -10,12 +10,14 @@
             <li><a href="http://www.auscope.org">AuScope.org<span></span></a></li>
             <li><a href="mailto:cg-portal@csiro.au">Contact Us<span></span></a></li>
             <li <%if (request.getRequestURL().toString().contains("/gmap.")) {%>class="current" <%} %>><a href="gmap.html">AuScope Discovery Portal<span></span></a></li>
+
+            <li><a href="static/user-guide/ug.htm" target="new">User Guide<span></span></a></li>
+
             <li <%if (request.getRequestURL().toString().contains("/links.")) {%>class="current" <%} %>><a href="links.html">Links<span></span></a></li>
          </ul>
       </div>
       <span id="latlng"></span>
       <div id="permalinkicon"><a href="javascript:void(0)"><img src="img/link.png" width="16" height="16"/></a></div>
       <div id="permalink"><a href="javascript:void(0)">Permanent Link</a></div>
-
 
    </div>


### PR DESCRIPTION
1. The user guide is created as a pre-build step
2. The pom file will now copy the user guide files and images into a static/\* directory (so the files are stored in the WAR file)
3. The menus have an extra item "user guide" that links to static/user-guide/ug.htm 
