### PR TITLE
Fix errror in BBOX ordering

### DIFF
--- a/src/main/webapp/mobile/js/assets/modules/service/layer/renderers/wms/WMS_1_3_0_Service.js
+++ b/src/main/webapp/mobile/js/assets/modules/service/layer/renderers/wms/WMS_1_3_0_Service.js
@@ -40,10 +40,10 @@ allModules.service('WMS_1_3_0_Service',['$rootScope','GoogleMapService','LayerMa
                 
                 // TODO: Add SRS/CRS parameter "getWMSMapViaProxy.do" to allow use of EPSG:3857
                 // BBOX in EPSG:4326
-                var bbox_4326 = bot.lat() + "," + leftLng + "," + top.lat() + "," + rightLng;
+                var bbox_4326 = leftLng + "," + bot.lat() + "," + rightLng + "," + top.lat();
                 
                 // BBOX in EPSG:3857
-                var bbox_3857 = bot3857[1] + "," + top3857[0] + "," + top3857[1] + "," + bot3857[0];
+                var bbox_3857 = top3857[0] + "," + bot3857[1] + "," + bot3857[0] + "," + top3857[1];
 
                 //VT: if the sld is too long, we will proxy the request via the server using httpPost
                 if (sldUrl) {


### PR DESCRIPTION
WMS 1.3.0 layers tesselate in a really weird way, this is because BBOX ordering is incorrect.

See link below for example
http://auscope-portal-dev.arrc.csiro.au/portal/mobile/index.htm?state=XQAAAQDvv6oAAAAAAAAAAD3vvojvvonvvqI3LO+/vzpDEwPvvpV3Te++v2QLFu+/vhLvv4svL++/vO+/mu++pe+/oFDvvqHvv5U9776K77+5bu++ru++gDTvvptiY3Tvv7ZDRmHvvrrvv4d9OxAzVhLvvpw1P+++tUrvvokobO+/t3YU776Y77+l776X77+p77+e77+TWljvvr1hTO++oe++umTvvrkJLilM776I776Q77+c776xYTJAHe+/q+++sO+/qQ0z776cUH4v77+h776277+jICANdAbvvrI877+MA+++qO++oT0C77+u7765776l77+Z77+fWu+/pO++r++/sBscNTXvvr3vvrLvvohr7767Su+/v++/qe+/ou+/p0A=